### PR TITLE
fix package versioning

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -32,8 +32,11 @@ main() {
 
   # Installing a package from GitHub and the filesystem works a bit differently.
   # The filesystem has a '/' at the start
-  if [[ "${package}" =~ / ]] && [[ ! "${package}" =~ ^/ ]]; then
-    package="${package}#${version}"
+  if [[ "${package}" =~ / ]]; then
+    if [[ ! "${package}" =~ ^/ ]]; then
+      package="${package}#${version}"
+  else
+    package="${package}@${version}"
   fi
 
   if [ -z "$output" ]; then

--- a/bin/package
+++ b/bin/package
@@ -18,14 +18,22 @@ main() {
     shift # past argument or value
   done
 
-  local package="${1/%@*/}"
-  local name=$(basename "${package%@*}")
+  # extract the package, which is the name up to the @
+  local package="${1%@*}"
+
+  # extract the version, which is everything after the @
+  local version="${1#*@}"
+
+  # The package name with no paths
+  local name=$(basename "${package}")
+
   local base=$(mktemp -d)
   local workdir="${base}/${name}-package"
 
-  # Installing a package from GitHub works a bit differently.
-  if [[ "${package}" =~ / ]]; then
-    package="${package/@/#}"
+  # Installing a package from GitHub and the filesystem works a bit differently.
+  # The filesystem has a '/' at the start
+  if [[ "${package}" =~ / ]] && [[ ! "${package}" =~ ^/ ]]; then
+    package="${package}#${version}"
   fi
 
   if [ -z "$output" ]; then


### PR DESCRIPTION
This fixes the package versioning so that a package can be installed from a version on github, a local file path, or a version from `npm`.

The problem with the existing code is that it throws away the version, and then will always install from head. This extracts the version correctly and then does the right thing with it depending on where the package comes from.